### PR TITLE
Change organization from deploybot-app to poseidon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 export CGO_ENABLED:=0
 
 VERSION=$(shell git describe --tags --match=v* --always --dirty)
-LD_FLAGS="-w -X github.com/deploybot-app/github-runner/cmd.version=$(VERSION)"
+LD_FLAGS="-w -X github.com/poseidon/github-runner/cmd.version=$(VERSION)"
 
-REPO=github.com/deploybot-app/github-runner
+REPO=github.com/poseidon/github-runner
 LOCAL_REPO=poseidon/github-runner
 IMAGE_REPO=quay.io/poseidon/github-runner
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# github-runner [![GoDoc](https://pkg.go.dev/badge/github.com/deploybot-app/github-runner.svg)](https://pkg.go.dev/github.com/deploybot-app/github-runner) [![Workflow](https://github.com/deploybot-app/github-runner/actions/workflows/test.yaml/badge.svg)](https://github.com/deploybot-app/github-runner/actions/workflows/test.yaml?query=branch%3Amain) [![Twitter](https://img.shields.io/badge/follow-news-1da1f2?logo=twitter)](https://twitter.com/deploybotapp)
+# github-runner [![GoDoc](https://pkg.go.dev/badge/github.com/poseidon/github-runner.svg)](https://pkg.go.dev/github.com/poseidon/github-runner) [![Workflow](https://github.com/poseidon/github-runner/actions/workflows/test.yaml/badge.svg)](https://github.com/poseidon/github-runner/actions/workflows/test.yaml?query=branch%3Amain) [![Twitter](https://img.shields.io/badge/follow-news-1da1f2?logo=twitter)](https://twitter.com/deploybotapp)
 
 `github-runner` provides the Github Actions [self-hosted](https://docs.github.com/en/actions/hosting-your-own-runners) [runner](https://github.com/actions/runner) as a container image that registers itself with Github.
 

--- a/cmd/gha/main.go
+++ b/cmd/gha/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/deploybot-app/github-runner/cmd"
+	"github.com/poseidon/github-runner/cmd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/deploybot-app/github-runner
+module github.com/poseidon/github-runner
 
 go 1.18
 


### PR DESCRIPTION
* Keeping the source code in deploybot-app and publishing the container image to quay.io/poseidon is unusual. Just keep it in the poseidon org