### PR TITLE
Update GitHub Actions Runner from v2.299.1 to v2.300.1

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.299.1
+ARG VERSION=2.300.1
 ARG ARCH=x64
-ARG SHA=147c14700c6cb997421b9a239c012197f11ea9854cd901ee88ead6fe73a72c74
+ARG SHA=36cd6111ec30c6b8b6c164b5cff597a52eae1c4a0356549434181aa58bc181a2
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.299.1
+ARG VERSION=2.300.1
 ARG ARCH=arm64
-ARG SHA=debe1cc9656963000a4fbdbb004f475ace5b84360ace2f7a191c1ccca6a16c00
+ARG SHA=99f3c0b5c194fdc750683d98894d8fa18493d7371e4d40b9d9b62a5bb57a6606
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.300.1