### PR TITLE
Update GitHub Actions Runner from v2.302.1 to v2.303.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.302.1
+ARG VERSION=2.303.0
 ARG ARCH=x64
-ARG SHA=3d357d4da3449a3b2c644dee1cc245436c09b6e5ece3e26a05bb3025010ea14d
+ARG SHA=e4a9fb7269c1a156eb5d5369232d0cd62e06bec2fd2b321600e85ac914a9cc73
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.302.1
+ARG VERSION=2.303.0
 ARG ARCH=arm64
-ARG SHA=cac05dc325a3fd86e0253bd5bda1831e1d550805c47d6e3cc6d248570ceb3b74
+ARG SHA=53f137fb4c00ac9906cbdf4b7c5c14e2e9555a2843d5c0171f6368207472464d
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.303.0