### PR TITLE
Change the base image from fedora to ubuntu

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,7 +3,7 @@ COPY . src
 RUN cd src && make bin
 
 
-FROM docker.io/fedora:38
+FROM docker.io/ubuntu:20.04
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,7 +3,7 @@ COPY . src
 RUN cd src && make bin
 
 
-FROM docker.io/fedora:38
+FROM docker.io/ubuntu:20.04
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 GitHub [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners) allow you to run GitHub Actions Workflows in environments you manage on your own infrastructure.
 
-`github-runner` packages the GitHub [runner](https://github.com/actions/runner) along with a tool to fetch a runner registration token dynamically on container start by acting as a GitHub App. On Kubernetes, you can create a ``Deployment of `github-runner` (or descendant image) Pods, watch them register and run jobs. A runner Pod can run one job ("ephemeral") or be long-lived.
+`github-runner` packages the GitHub [runner](https://github.com/actions/runner) along with a tool to fetch a runner registration token dynamically on container start by acting as a GitHub App. On Kubernetes, you can create a Deployment of `github-runner` (or descendant image) Pods, watch them register and run jobs. A runner Pod can run one job ("ephemeral") or be long-lived.
 
 *Note: GitHub personal access tokens can also fetch runner registration tokens, but at most organizations, using a personal token or a robot user isn't an option.*
 
@@ -89,8 +89,7 @@ Configure github-runner to act as a GitHub App to obtain a self-hosted runner re
 
 More complex needs may be handled by more complex [projects](https://github.com/actions-runner-controller/actions-runner-controller) (out of scope):
 
-* Auto-scaling in runners
-* Ephemeral runners
+* Auto-scaling runners
 
 ## Security
 

--- a/scripts/build
+++ b/scripts/build
@@ -4,13 +4,16 @@
 # requires ARCH variable
 set -ex
 
+# Avoid the tzdata prompt
+export DEBIAN_FRONTEND=noninteractive
+
 # base packages
 # https://github.com/actions/runner/blob/main/docs/start/envlinux.md#full-dependencies-list
-dnf -y update
-dnf -y install \
-  git curl tar zip make dumb-init \
-  lttng-ust openssl-libs krb5-libs zlib libicu
-dnf clean all
+apt-get update
+apt-get install --no-install-recommends -y \
+  liblttng-ust0 libkrb5-3 zlib1g libssl1.1 libicu66 \
+  git curl tar zip make dumb-init ca-certificates
+apt-get clean
 
 # Create a folder
 mkdir actions-runner && cd actions-runner


### PR DESCRIPTION
* Use fedora internally, but for external examples and demos it can be useful to have the base image be debian/ubuntu
* Use docker.io/ubuntu:20.04 (rather than 22.04) because the GitHub Actions Runner requests system packages from 18.04 and 20.04, they don't seem to be quite up-to-date

Rel: https://github.com/actions/runner/blob/main/docs/start/envlinux.md#full-dependencies-list