### PR TITLE
Update GitHub Actions runner from v2.304 to v2.305

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.304.0
+ARG VERSION=2.305.0
 ARG ARCH=x64
-ARG SHA=292e8770bdeafca135c2c06cd5426f9dda49a775568f45fcc25cc2b576afc12f
+ARG SHA=737bdcef6287a11672d6a5a752d70a7c96b4934de512b7eb283be6f51a563f2f
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.304.0
+ARG VERSION=2.305.0
 ARG ARCH=arm64
-ARG SHA=34c49bd0e294abce6e4a073627ed60dc2f31eee970c13d389b704697724b31c6
+ARG SHA=63d7b0ba495055e390ac057dc67d721ed78113990fa837a20b141a75044e152a
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.305.0