### PR TITLE
Update GitHub Actions Runner from v2.306.0 to v2.307.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.306.0
+ARG VERSION=2.307.0
 ARG ARCH=x64
-ARG SHA=b0a090336f0d0a439dac7505475a1fb822f61bbb36420c7b3b3fe6b1bdc4dbaa
+ARG SHA=13be5edefd6298185ef57dbb97cb60481009d8058819d7971baef2773b4544c1
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.306.0
+ARG VERSION=2.307.0
 ARG ARCH=arm64
-ARG SHA=842a9046af8439aa9bcabfe096aacd998fc3af82b9afe2434ddd77b96f872a83
+ARG SHA=5ed2ca5a6f99336510d738ec92b6d42b52373d9724959b95987bf254c43e060a
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.307.0