### PR TITLE
Update GitHub Actions Runner from v2.307.0 to v2.307.1

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.307.0
+ARG VERSION=2.307.1
 ARG ARCH=x64
-ARG SHA=13be5edefd6298185ef57dbb97cb60481009d8058819d7971baef2773b4544c1
+ARG SHA=038c9e98b3912c5fd6d0b277f2e4266b2a10accc1ff8ff981b9971a8e76b5441
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.307.0
+ARG VERSION=2.307.1
 ARG ARCH=arm64
-ARG SHA=5ed2ca5a6f99336510d738ec92b6d42b52373d9724959b95987bf254c43e060a
+ARG SHA=01edc84342ef4128a8f19bc2f33709b40f2f1c40e250e2a4c5e0adf620044ab3
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.307.1