### PR TITLE
Update GitHub Actions Runner from v2.308.0 to v2.309.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.308.0
+ARG VERSION=2.309.0
 ARG ARCH=x64
-ARG SHA=9f994158d49c5af39f57a65bf1438cbae4968aec1e4fec132dd7992ad57c74fa
+ARG SHA=2974243bab2a282349ac833475d241d5273605d3628f0685bd07fb5530f9bb1a
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.308.0
+ARG VERSION=2.309.0
 ARG ARCH=arm64
-ARG SHA=e39b3137fcaad3262e1def26d3e42cdd810c831a3c836deeb560a2266338b503
+ARG SHA=b172da68eef96d552534294e4fb0a3ff524e945fc5d955666bab24eccc6ed149
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.309.0