### PR TITLE
Update GitHub Actions Runner from v2.309.0 to v2.310.2

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.309.0
+ARG VERSION=2.310.2
 ARG ARCH=x64
-ARG SHA=2974243bab2a282349ac833475d241d5273605d3628f0685bd07fb5530f9bb1a
+ARG SHA=fb28a1c3715e0a6c5051af0e6eeff9c255009e2eec6fb08bc2708277fbb49f93
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.309.0
+ARG VERSION=2.310.2
 ARG ARCH=arm64
-ARG SHA=b172da68eef96d552534294e4fb0a3ff524e945fc5d955666bab24eccc6ed149
+ARG SHA=a64e2d69d022c269bfa5be9c3fbceecc95f6ec415688b4e85bbccd98e30a85b7
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.310.2