### PR TITLE
Update GitHub Actions runner from 2.312.0 to 2.313.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.312.0
+ARG VERSION=2.313.0
 ARG ARCH=x64
-ARG SHA=85c1bbd104d539f666a89edef70a18db2596df374a1b51670f2af1578ecbe031
+ARG SHA=56910d6628b41f99d9a1c5fe9df54981ad5d8c9e42fc14899dcc177e222e71c4
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.312.0
+ARG VERSION=2.313.0
 ARG ARCH=arm64
-ARG SHA=322e9ba6f0ec2350e6702457c453c5ea2517b5a6f3eac0f58a59110e6aa50fb0
+ARG SHA=44c306066a32c8df8b30b1258b19ed3437285baa4a1d6289f22cf38eca474603
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.313.0