### PR TITLE
Update GitHub Action Runner from v2.314.1 to v2.315.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.314.1
+ARG VERSION=2.315.0
 ARG ARCH=x64
-ARG SHA=6c726a118bbe02cd32e222f890e1e476567bf299353a96886ba75b423c1137b5
+ARG SHA=6362646b67613c6981db76f4d25e68e463a9af2cc8d16e31bfeabe39153606a0
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.314.1
+ARG VERSION=2.315.0
 ARG ARCH=arm64
-ARG SHA=3d27b1340086115a118e28628a11ae727ecc6b857430c4b1b6cbe64f1f3b6789
+ARG SHA=d9d58b178eca5fb65d93d151f3b62bde967f8cbec7c72e9b0976e9312b7f7dda
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.315.0