### PR TITLE
Update base image from 20.04 to 24.04

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,7 +3,7 @@ COPY . src
 RUN cd src && make bin
 
 
-FROM docker.io/ubuntu:20.04
+FROM docker.io/ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,7 +3,7 @@ COPY . src
 RUN cd src && make bin
 
 
-FROM docker.io/ubuntu:20.04
+FROM docker.io/ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ image: \
 
 image-%:
 	buildah bud -f Dockerfile.$* \
+		--security-opt seccomp=unconfined \
 		-t $(LOCAL_REPO):$(VERSION)-$* \
 		--layers \
 		--arch $* --override-arch $* \
@@ -52,6 +53,7 @@ manifest:
 run:
 	podman run \
 		-it \
-		--env-file $(HOME)/.secrets/vault/apps/github-runner/runner.env \
-		-v ~/.secrets/vault/apps/github-runner:/etc/github-runner:Z \
-		poseidon/github-runner:$(VERSION)
+		--env-file ~/.config/github-runner/github-runner.env \
+		-v ~/.config/github-runner:/etc/github-runner:Z \
+		-v /run:/run \
+		localhost/poseidon/github-runner:$(VERSION)-amd64

--- a/scripts/build
+++ b/scripts/build
@@ -11,7 +11,7 @@ export DEBIAN_FRONTEND=noninteractive
 # https://github.com/actions/runner/blob/main/docs/start/envlinux.md#full-dependencies-list
 apt-get update
 apt-get install --no-install-recommends -y \
-  liblttng-ust0 libkrb5-3 zlib1g libssl1.1 libicu66 \
+  liblttng-ust-dev libkrb5-3 zlib1g libssl-dev libicu74 \
   git curl tar zip make dumb-init ca-certificates
 apt-get clean
 


### PR DESCRIPTION
* Update packages required by the GitHub Actions Runner to their Ubuntu 24.04 equivalents