### PR TITLE
Revert "Revert to ubuntu:20.04 and workaround cleanup bug"

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,8 +3,7 @@ COPY . src
 RUN cd src && make bin
 
 
-#FROM docker.io/ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15
-FROM docker.io/ubuntu:20.04
+FROM docker.io/ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,8 +3,7 @@ COPY . src
 RUN cd src && make bin
 
 
-#FROM docker.io/ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15
-FROM docker.io/ubuntu:20.04
+FROM docker.io/ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"

--- a/scripts/build
+++ b/scripts/build
@@ -11,7 +11,7 @@ export DEBIAN_FRONTEND=noninteractive
 # https://github.com/actions/runner/blob/main/docs/start/envlinux.md#full-dependencies-list
 apt-get update
 apt-get install --no-install-recommends -y \
-  liblttng-ust0 libkrb5-3 zlib1g libssl1.1 libicu66 \
+  liblttng-ust-dev libkrb5-3 zlib1g libssl-dev libicu74 \
   git curl tar zip make dumb-init ca-certificates
 apt-get clean
 

--- a/scripts/start
+++ b/scripts/start
@@ -22,9 +22,8 @@ fetch_token() {
 
 cleanup() {
   echo "Cleanup"
-  pkill -f './bin/Runner.Listener'
   ./config.sh remove --token $(fetch_token)
-  exit 0
+  exit
 }
 
 RUNNER_TOKEN=$(fetch_token)


### PR DESCRIPTION
* Github cleanup bug isn't solved by the workaround, I've solved it separately by allowing unclean pod failures in jobs.