### PR TITLE
Update GitHub Actions runner from v2.317.0 to v2.318.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.317.0
+ARG VERSION=2.318.0
 ARG ARCH=x64
-ARG SHA=9e883d210df8c6028aff475475a457d380353f9d01877d51cc01a17b2a91161d
+ARG SHA=28ed88e4cedf0fc93201a901e392a70463dbd0213f2ce9d57a4ab495027f3e2f
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.317.0
+ARG VERSION=2.318.0
 ARG ARCH=arm64
-ARG SHA=7e8e2095d2c30bbaa3d2ef03505622b883d9cb985add6596dbe2f234ece308f3
+ARG SHA=c4d03f1fdfc74e4e29cc403917be2bb24a714740bd250401fba5a4670e2c6070
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.318.0