### PR TITLE
bump runner from 2.322.0 => 2.323.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.322.0
+ARG VERSION=2.323.0
 ARG ARCH=x64
-ARG SHA=b13b784808359f31bc79b08a191f5f83757852957dd8fe3dbfcc38202ccf5768
+ARG SHA=0dbc9bf5a58620fc52cb6cc0448abcca964a8d74b5f39773b7afcad9ab691e19
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.322.0
+ARG VERSION=2.323.0
 ARG ARCH=arm64
-ARG SHA=a96b0cec7b0237ca5e4210982368c6f7d8c2ab1e5f6b2604c1ccede9cedcb143
+ARG SHA=9cb778fffd4c6d8bd74bc4110df7cb8c0122eb62fda30b389318b265d3ade538
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
https://github.com/actions/runner/releases/tag/v2.323.0