### PR TITLE
Update GitHub Actions runner from v2.323.0 to v2.324.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.323.0
+ARG VERSION=2.324.0
 ARG ARCH=x64
-ARG SHA=0dbc9bf5a58620fc52cb6cc0448abcca964a8d74b5f39773b7afcad9ab691e19
+ARG SHA=e8e24a3477da17040b4d6fa6d34c6ecb9a2879e800aa532518ec21e49e21d7b4
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.323.0
+ARG VERSION=2.324.0
 ARG ARCH=arm64
-ARG SHA=9cb778fffd4c6d8bd74bc4110df7cb8c0122eb62fda30b389318b265d3ade538
+ARG SHA=b5a5cf1138064afd0f0fb1a4a493adaa9bff5485ace3575e99547f004dbb20fa
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.324.0