### PR TITLE
Update GitHub Actions Runner from v2.324.0 to v2.325.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.324.0
+ARG VERSION=2.325.0
 ARG ARCH=x64
-ARG SHA=e8e24a3477da17040b4d6fa6d34c6ecb9a2879e800aa532518ec21e49e21d7b4
+ARG SHA=5020da7139d85c776059f351e0de8fdec753affc9c558e892472d43ebeb518f4
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.324.0
+ARG VERSION=2.325.0
 ARG ARCH=arm64
-ARG SHA=b5a5cf1138064afd0f0fb1a4a493adaa9bff5485ace3575e99547f004dbb20fa
+ARG SHA=0e916ad0d354089d320011c132d46bdbe3353c8b925a2e1056c7c8e85d2f2490
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.325.0