### PR TITLE
Update GitHub Actions runner from v2.330.0 to v2.332.0

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.330.0
+ARG VERSION=2.332.0
 ARG ARCH=x64
-ARG SHA=af5c33fa94f3cc33b8e97937939136a6b04197e6dadfcfb3b6e33ae1bf41e79a
+ARG SHA=f2094522a6b9afeab07ffb586d1eb3f190b6457074282796c497ce7dce9e0f2a
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.330.0
+ARG VERSION=2.332.0
 ARG ARCH=arm64
-ARG SHA=9cb43527912086c7c8fb4119cb06409fcbcbd6f93a2d8507f30b07c495620f5c
+ARG SHA=b72f0599cdbd99dd9513ab64fcb59e424fc7359c93b849e8f5efdd5a72f743a6
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
* https://github.com/actions/runner/releases/tag/v2.332.0