### PR TITLE
Update GitHub Actions runner to v2.335.1

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.333.1
+ARG VERSION=2.335.1
 ARG ARCH=x64
-ARG SHA=18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74
+ARG SHA=4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf
 
 COPY scripts /scripts
 RUN /scripts/build

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,9 +9,9 @@ LABEL org.opencontainers.image.title="github-runner"
 LABEL org.opencontainers.image.source="https://github.com/poseidon/github-runner"
 LABEL org.opencontainers.image.vendor="Poseidon Labs"
 
-ARG VERSION=2.333.1
+ARG VERSION=2.335.1
 ARG ARCH=arm64
-ARG SHA=69ac7e5692f877189e7dddf4a1bb16cbbd6425568cd69a0359895fac48b9ad3b
+ARG SHA=6d1e85bfd1a506a8b17c1f1b9b57dba458ffed90898799aaa9f599520b0d9207
 
 COPY scripts /scripts
 RUN /scripts/build


### PR DESCRIPTION
## Summary

* Update linux x64 SHA to 4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf
* Update linux arm64 SHA to 6d1e85bfd1a506a8b17c1f1b9b57dba458ffed90898799aaa9f599520b0d9207

## Validation

* make test